### PR TITLE
docs: update browser support link in polyfills

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -11,7 +11,7 @@
  * automatically update themselves. This includes Safari >= 10, Chrome >= 55 (including Opera),
  * Edge >= 13 on the desktop, and iOS 10 and Chrome on mobile.
  *
- * Learn more in https://angular.io/docs/ts/latest/guide/browser-support.html
+ * Learn more in https://angular.io/guide/browser-support
  */
 
 /***************************************************************************************************


### PR DESCRIPTION
## Summary
- update polyfills comment to point to current Angular browser support documentation

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_689050b0b2fc8322a300bd25a4b39dcf